### PR TITLE
Added callback when image is navigated

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Lightbox can be customized with the following properties
 |showTitle|true|Determines if title should be shown if available|
 |keyboardInteraction|true|Determine if keyboard shortcuts will be allowed <br> See below section for available <br> Shortcuts|
 |doubleClickZoom|4|Determine how much to zoom in if double clicked.<br> default 4 means close to 400%.<br> Setting it to 0 will disable <br> doubleclick/ double tap zoom|
+|onNavigateImage|null|Callback when image is navigated. It accepts the<br/>new index as its parameter.|
 
 
 ### Keyboard Shortcut:

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,9 @@ export default class Lightbox extends React.Component {
         if(current >= this.props.images.length) current = 0;
         else if (current < 0) current = this.props.images.length -1;
         this.setState({current, x: 0, y: 0, zoom: 1, rotate: 0, loading: true});
+        if(typeof this.props.onNavigateImage === 'function') {
+            this.props.onNavigateImage(current)
+        }
     }
     startMove = (e) => {
         if(this.state.zoom <= 1) return false;


### PR DESCRIPTION
In some cases it's needed to get the index of the current image index (`current`) back to the parent component. This PR adds the possibility of passing the prop `onNavigateImage`, which is a function that accepts the index as its parameter.